### PR TITLE
chore: promote dev for the 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Umbra follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and will 
 
 ## Unreleased
 
+## [0.1.0] - 2026-08-19
+
+First public release of `umbra-cli`.
+
 ### Added
 
 - Initial public source release of the CLI, Console, Dev CVM, Security CVM, specifications, self-host templates, and CI/release definitions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "umbra-cli"
-version = "0.3.0-beta.3"
+version = "0.1.0"
 dependencies = [
  "anstyle",
  "atlas-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["cli", "cvms/dev/user-sandbox/atls-connect"]
 
 [workspace.package]
-version = "0.3.0-beta.3"
+version = "0.1.0"
 edition = "2021"
 authors = ["Umbra maintainers"]
 homepage = "https://github.com/concrete-security/umbra"

--- a/cli/src/atls_policy_store.rs
+++ b/cli/src/atls_policy_store.rs
@@ -241,14 +241,14 @@ mod tests {
     #[test]
     fn store_path_uses_config_cvms_dir() {
         assert_eq!(
-            store_path(Path::new("/tmp/concrete"), "cvm-1"),
-            PathBuf::from("/tmp/concrete/cvms/cvm-1.atls-policy.json")
+            store_path(Path::new("/tmp/umbra"), "cvm-1"),
+            PathBuf::from("/tmp/umbra/cvms/cvm-1.atls-policy.json")
         );
     }
 
     #[test]
     fn cvm_id_from_store_path_yields_cvm_id_only_for_canonical_path() {
-        let config_dir = Path::new("/tmp/concrete");
+        let config_dir = Path::new("/tmp/umbra");
         let canonical = config_dir
             .join("cvms")
             .join("cvm-s7oz4pkm2r3c5g6pta35gm5taq.atls-policy.json");
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn update_policy_refuses_to_overwrite_changed_local_trust_in_json_mode() {
-        let dir = std::env::temp_dir().join(format!("concrete-cvm-policy-test-{}", Uuid::new_v4()));
+        let dir = std::env::temp_dir().join(format!("umbra-cvm-policy-test-{}", Uuid::new_v4()));
         let cvm_id = "00000000-0000-4000-8000-000000000001";
         let old_hash = "a".repeat(64);
         let new_hash = "b".repeat(64);
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn update_policy_accepts_unchanged_local_trust() {
-        let dir = std::env::temp_dir().join(format!("concrete-cvm-policy-test-{}", Uuid::new_v4()));
+        let dir = std::env::temp_dir().join(format!("umbra-cvm-policy-test-{}", Uuid::new_v4()));
         let cvm_id = "00000000-0000-4000-8000-000000000001";
         write(
             &dir,

--- a/console/alembic/versions/0034_connect_oauth_schema.py
+++ b/console/alembic/versions/0034_connect_oauth_schema.py
@@ -7,7 +7,7 @@ Create Date: 2026-08-17
 The pre-Umbra compatibility branch left these objects as lineage-only no-ops so
 fresh databases would not install a then-removed private feature. Connect is now
 a public Umbra surface, so this revision creates the tables and audit actions on
-every database that reached ``0033_public_legacy_merge``. Existing Concrete
+every database that reached ``0033_public_legacy_merge``. Existing pre-rename
 schema is retained: ``CREATE IF NOT EXISTS`` / ``ADD VALUE IF NOT EXISTS`` keep
 a migrated database intact, and ciphertext CHECKs accept Umbra v2 envelopes as
 well as legacy v1.

--- a/console/src/umbra_console/profile_secrets.py
+++ b/console/src/umbra_console/profile_secrets.py
@@ -14,6 +14,11 @@ from umbra_console.config import load_settings
 SECRET_INJECTION_KEK_ENV = "SECRET_INJECTION_KEK_B64"
 SECRET_INJECTION_ENVELOPE_VERSION = "v2"
 SECRET_INJECTION_LEGACY_ENVELOPE_VERSION = "v1"
+# AAD namespace for `v1:` ciphertext written by pre-rename deployments. The
+# exact bytes are bound into every legacy envelope, so the value is operator
+# configuration carried by migrated deployments; fresh installs never set it
+# and therefore cannot read `v1:` rows.
+LEGACY_SECRET_AAD_NAMESPACE_ENV = "LEGACY_SECRET_AAD_NAMESPACE"
 SECRET_INJECTION_NONCE_BYTES = 12
 SECRET_INJECTION_KEY_BYTES = 32
 SECRET_INJECTION_RENDERED_MAX_LEN = 8192
@@ -434,37 +439,34 @@ def _valid_dns_name(host: str) -> bool:
     return len(labels) >= 2 and all(SECRET_HOST_DNS_LABEL_RE.fullmatch(label) for label in labels)
 
 
+def _legacy_aad_namespace() -> str:
+    namespace = load_settings().raw.get(LEGACY_SECRET_AAD_NAMESPACE_ENV, "").strip()
+    if not namespace:
+        raise ValueError(f"{LEGACY_SECRET_AAD_NAMESPACE_ENV} is required to read legacy v1 ciphertext")
+    return namespace
+
+
+def _aad_domain(family: str, version: str) -> str:
+    if version == SECRET_INJECTION_LEGACY_ENVELOPE_VERSION:
+        return f"{_legacy_aad_namespace()}.{family}.v1"
+    return f"umbra.{family}.v2"
+
+
 def _secret_aad(profile_id: Any, injection_id: str, version: str) -> bytes:
-    domain = (
-        "concrete.profile_secret_material.v1"
-        if version == SECRET_INJECTION_LEGACY_ENVELOPE_VERSION
-        else "umbra.profile_secret_material.v2"
-    )
+    domain = _aad_domain("profile_secret_material", version)
     return f"{domain}:{profile_id}:{injection_id}".encode("utf-8")
 
 
 def _user_secret_aad(user_id: Any, name: str, version: str) -> bytes:
-    domain = (
-        "concrete.user_secret_material.v1"
-        if version == SECRET_INJECTION_LEGACY_ENVELOPE_VERSION
-        else "umbra.user_secret_material.v2"
-    )
+    domain = _aad_domain("user_secret_material", version)
     return f"{domain}:{user_id}:{name}".encode("utf-8")
 
 
 def _oauth_client_secret_aad(entity_id: Any, name: str, version: str) -> bytes:
-    domain = (
-        "concrete.oauth_integration.v1"
-        if version == SECRET_INJECTION_LEGACY_ENVELOPE_VERSION
-        else "umbra.oauth_integration.v2"
-    )
+    domain = _aad_domain("oauth_integration", version)
     return f"{domain}:{entity_id}:{name}".encode("utf-8")
 
 
 def _managed_secret_aad(profile_id: Any, injection_id: str, version: str) -> bytes:
-    domain = (
-        "concrete.managed_secret.v1"
-        if version == SECRET_INJECTION_LEGACY_ENVELOPE_VERSION
-        else "umbra.managed_secret.v2"
-    )
+    domain = _aad_domain("managed_secret", version)
     return f"{domain}:{profile_id}:{injection_id}".encode("utf-8")

--- a/console/src/umbra_console/routes.py
+++ b/console/src/umbra_console/routes.py
@@ -1421,6 +1421,7 @@ def render_dev_cvm_compose_config(resolved: dict[str, object]) -> str:
             "    environment:",
             "      DEV_CVM_SSH_HOST: user-sandbox",
             "      DEV_CVM_SSH_PORT: \"22\"",
+            "      DEV_TUNNEL_PATH: ${DEV_TUNNEL_PATH:-/umbra/tunnel}",
             # Deliberately not gated on user-sandbox health: the tunnel dials
             # per connection, while shade's nginx needs this upstream
             # resolvable immediately or it crash-loops through certbot's whole

--- a/console/src/umbra_console/routes_oauth.py
+++ b/console/src/umbra_console/routes_oauth.py
@@ -817,8 +817,8 @@ async def delete_profile_managed_secret(
 def callback_page(status_code: int, message: str) -> HTMLResponse:
     body = (
         "<!doctype html>\n"
-        '<html><head><meta charset="utf-8"><title>Concrete</title></head>\n'
-        f"<body><h1>Concrete</h1><p>{html.escape(message)}</p></body></html>\n"
+        '<html><head><meta charset="utf-8"><title>Umbra</title></head>\n'
+        f"<body><h1>Umbra</h1><p>{html.escape(message)}</p></body></html>\n"
     )
     return HTMLResponse(content=body, status_code=status_code)
 

--- a/console/src/umbra_console/scheduler.py
+++ b/console/src/umbra_console/scheduler.py
@@ -3433,6 +3433,7 @@ def build_cvm_launch_env(
         "AUTHORIZED_SSH_KEYS_B64": b64_text(authorized_keys),
         "SANDBOX_ENV_PLACEHOLDERS_B64": b64_text(sandbox_env),
         "CONSOLE_URL": console_url,
+        "DEV_TUNNEL_PATH": ",".join(dev_tunnel_paths()),
     }
     env.update(dstack_docker_pull_env())
     return env, binding
@@ -3473,7 +3474,44 @@ def security_cvm_atls_policy(snapshot: Any) -> dict[str, Any]:
     return policy
 
 
+DEV_TUNNEL_CANONICAL_PATH = "/umbra/tunnel"
+DEV_TUNNEL_EXTRA_PATHS_ENV = "DEV_TUNNEL_EXTRA_PATHS"
+DEV_TUNNEL_PATH_ALLOWED_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._~/-"
+)
+
+
+def dev_tunnel_paths() -> list[str]:
+    """The canonical tunnel path plus operator-configured aliases.
+
+    Aliases exist so clients that predate the current path keep SSH access;
+    they are deployment configuration, never hardcoded here.
+    """
+    raw = load_settings().raw.get(DEV_TUNNEL_EXTRA_PATHS_ENV, "").strip()
+    paths = [DEV_TUNNEL_CANONICAL_PATH]
+    for part in raw.split(","):
+        path = part.strip()
+        if not path:
+            continue
+        if not path.startswith("/") or not set(path) <= DEV_TUNNEL_PATH_ALLOWED_CHARS:
+            raise RuntimeError(f"{DEV_TUNNEL_EXTRA_PATHS_ENV} entries must be absolute URL paths")
+        if path not in paths:
+            paths.append(path)
+    return paths
+
+
 def render_dev_cvm_shade_config(snapshot: Any, *, name: str) -> str:
+    route_lines: list[str] = []
+    for path in dev_tunnel_paths():
+        route_lines.extend(
+            [
+                f"    - path: {path}",
+                "      service: dev-tunnel",
+                "      port: 8090",
+                "      websocket: true",
+                "      cors: false",
+            ]
+        )
     return "\n".join(
         [
             "app:",
@@ -3488,18 +3526,7 @@ def render_dev_cvm_shade_config(snapshot: Any, *, name: str) -> str:
             f"  instance_type: {_row_value(snapshot, 'instance_type')}",
             f"  region: {_row_value(snapshot, 'region')}",
             "  routes:",
-            "    - path: /umbra/tunnel",
-            "      service: dev-tunnel",
-            "      port: 8090",
-            "      websocket: true",
-            "      cors: false",
-            # Transition alias: concrete-branded CLIs (<= 0.4.x) dial
-            # /concrete/tunnel and must keep SSH access after rebind.
-            "    - path: /concrete/tunnel",
-            "      service: dev-tunnel",
-            "      port: 8090",
-            "      websocket: true",
-            "      cors: false",
+            *route_lines,
             "",
         ]
     )

--- a/console/tests/test_profile_secrets.py
+++ b/console/tests/test_profile_secrets.py
@@ -228,23 +228,38 @@ def test_user_and_profile_secret_aads_are_distinct_families_failure(monkeypatch)
         pytest.param(
             decrypt_profile_secret_value,
             {"profile_id": "profile-a", "injection_id": "anthropic-key"},
-            "concrete.profile_secret_material.v1:profile-a:anthropic-key",
+            "legacyns.profile_secret_material.v1:profile-a:anthropic-key",
             id="profile",
         ),
         pytest.param(
             decrypt_user_secret_value,
             {"user_id": "user-a", "name": "slack-user-token"},
-            "concrete.user_secret_material.v1:user-a:slack-user-token",
+            "legacyns.user_secret_material.v1:user-a:slack-user-token",
             id="user",
         ),
     ],
 )
 def test_secret_values_legacy_v1_reads_success(monkeypatch, decrypt, kwargs, aad) -> None:
-    """Legacy v1 rows remain readable only under their historical AAD."""
+    """Legacy v1 rows remain readable only under the configured historical AAD namespace."""
     monkeypatch.setenv("SECRET_INJECTION_KEK_B64", TEST_KEK)
+    monkeypatch.setenv("LEGACY_SECRET_AAD_NAMESPACE", "legacyns")
     ciphertext = _ciphertext_for_aad(version="v1", aad=aad, value="legacy-secret")
 
     assert decrypt(**kwargs, ciphertext=ciphertext) == "legacy-secret"
+
+
+def test_secret_values_legacy_v1_read_requires_namespace_failure(monkeypatch) -> None:
+    """Without the operator-configured namespace, v1 ciphertext is unreadable, with a clear error."""
+    monkeypatch.setenv("SECRET_INJECTION_KEK_B64", TEST_KEK)
+    monkeypatch.delenv("LEGACY_SECRET_AAD_NAMESPACE", raising=False)
+    ciphertext = _ciphertext_for_aad(
+        version="v1",
+        aad="legacyns.profile_secret_material.v1:profile-a:anthropic-key",
+        value="legacy-secret",
+    )
+
+    with pytest.raises(ValueError, match="LEGACY_SECRET_AAD_NAMESPACE"):
+        decrypt_profile_secret_value(profile_id="profile-a", injection_id="anthropic-key", ciphertext=ciphertext)
 
 
 @pytest.mark.parametrize(
@@ -273,8 +288,9 @@ def test_secret_values_cross_version_aad_fallback_failure(
     version,
     wrong_aad,
 ) -> None:
-    """A valid tag under the wrong product/version AAD is never retried."""
+    """A valid tag under the wrong namespace/version AAD is never retried."""
     monkeypatch.setenv("SECRET_INJECTION_KEK_B64", TEST_KEK)
+    monkeypatch.setenv("LEGACY_SECRET_AAD_NAMESPACE", "legacyns")
     ciphertext = _ciphertext_for_aad(version=version, aad=wrong_aad)
 
     with pytest.raises(InvalidTag):

--- a/console/tests/test_scheduler.py
+++ b/console/tests/test_scheduler.py
@@ -732,6 +732,7 @@ def security_cvm_resource_row(**overrides):
 
 def test_build_cvm_launch_env_binds_runtime_material(monkeypatch) -> None:
     monkeypatch.delenv("CONSOLE_URL", raising=False)
+    monkeypatch.setenv("DEV_TUNNEL_EXTRA_PATHS", "/legacy-cli/tunnel")
 
     env, binding = scheduler.build_cvm_launch_env(
         launch_snapshot(),
@@ -755,6 +756,7 @@ def test_build_cvm_launch_env_binds_runtime_material(monkeypatch) -> None:
     assert "SECURITY_CVM_ATLS_POLICY_B64" not in env
     assert "SECURITY_CVM_ATLS_POLICY_GZIP_B64" not in env
     assert env["CONSOLE_URL"] == ""
+    assert env["DEV_TUNNEL_PATH"] == "/umbra/tunnel,/legacy-cli/tunnel"
     assert binding == {
         "cvm_id": "00000000-0000-4000-8000-000000000031",
         "console_url": "",
@@ -880,7 +882,8 @@ def test_cvm_launch_provider_name_is_managed_scoped() -> None:
     )
 
 
-def test_render_dev_cvm_shade_config_routes_tunnel_websocket() -> None:
+def test_render_dev_cvm_shade_config_routes_tunnel_websocket(monkeypatch) -> None:
+    monkeypatch.delenv("DEV_TUNNEL_EXTRA_PATHS", raising=False)
     shade = scheduler.render_dev_cvm_shade_config(launch_snapshot(), name="umbra-v0-cvm-test")
 
     assert "name: umbra-v0-cvm-test" in shade
@@ -889,8 +892,24 @@ def test_render_dev_cvm_shade_config_routes_tunnel_websocket() -> None:
     assert "region: FR-PARIS-1" in shade
     assert "dev-tunnel:" in shade
     assert "path: /umbra/tunnel" in shade
-    assert "path: /concrete/tunnel" in shade
     assert "websocket: true" in shade
+
+
+def test_render_dev_cvm_shade_config_routes_extra_tunnel_paths(monkeypatch) -> None:
+    """Operator-configured aliases render as additional routes to the same tunnel."""
+    monkeypatch.setenv("DEV_TUNNEL_EXTRA_PATHS", "/legacy-cli/tunnel, /umbra/tunnel,")
+    shade = scheduler.render_dev_cvm_shade_config(launch_snapshot(), name="umbra-v0-cvm-test")
+
+    assert shade.count("service: dev-tunnel") == 2
+    assert shade.count("path: /umbra/tunnel") == 1
+    assert "path: /legacy-cli/tunnel" in shade
+
+
+def test_dev_tunnel_extra_paths_rejects_relative_paths_failure(monkeypatch) -> None:
+    monkeypatch.setenv("DEV_TUNNEL_EXTRA_PATHS", "legacy-cli/tunnel")
+
+    with pytest.raises(RuntimeError, match="DEV_TUNNEL_EXTRA_PATHS"):
+        scheduler.dev_tunnel_paths()
 
 
 def test_security_cvm_provider_name_is_managed_scoped() -> None:

--- a/cvms/dev/docker-compose.yml
+++ b/cvms/dev/docker-compose.yml
@@ -84,6 +84,7 @@ services:
     environment:
       DEV_CVM_SSH_HOST: user-sandbox
       DEV_CVM_SSH_PORT: "22"
+      DEV_TUNNEL_PATH: ${DEV_TUNNEL_PATH:-/umbra/tunnel}
     # Deliberately not gated on user-sandbox health: the tunnel dials the
     # sandbox per connection and reports connection_error until it is up,
     # while shade's nginx needs this upstream resolvable immediately —

--- a/cvms/dev/shade.yml
+++ b/cvms/dev/shade.yml
@@ -13,9 +13,3 @@ cvm:
       port: 8090
       websocket: true
       cors: false
-    # Transition alias for concrete-branded CLIs (<= 0.4.x).
-    - path: /concrete/tunnel
-      service: dev-tunnel
-      port: 8090
-      websocket: true
-      cors: false

--- a/cvms/dev/tests/compose_smoke.sh
+++ b/cvms/dev/tests/compose_smoke.sh
@@ -82,6 +82,7 @@ export SECURITY_CVM_FQDN="sc.example.com"
 export SECURITY_CVM_PROXY_PORT="8080"
 export SECURITY_CVM_PROXY_TOKEN="compose-smoke-token"
 export DEV_CVM_CONTROL_TOKEN="compose-smoke-dev-control-token"
+export DEV_TUNNEL_PATH="/umbra/tunnel,/legacy-cli/tunnel"
 
 rendered_compose="$(
   docker compose -p "$PROJECT" -f "$ROOT/cvms/dev/docker-compose.yml" -f "$TMPDIR/compose.override.yml" config
@@ -108,8 +109,8 @@ docker compose -p "$PROJECT" -f "$ROOT/cvms/dev/docker-compose.yml" -f "$TMPDIR/
       dev@user-sandbox '"'"'test "$(id -u)" = 1001 && test "$VERIFY_PLACEHOLDER" = compose-smoke && test -L /home/dev/.claude.json && python3 -m json.tool /home/dev/.claude.json >/dev/null'"'"'
   ' <"$TMPDIR/id_ed25519"
 
-# The canonical path and the concrete-CLI transition alias must both relay.
-for tunnel_path in /umbra/tunnel /concrete/tunnel; do
+# The canonical path and a configured alias must both relay.
+for tunnel_path in /umbra/tunnel /legacy-cli/tunnel; do
 python3 - "$tunnel_port" "$tunnel_path" <<'PY'
 import base64
 import os

--- a/cvms/dev/tests/tunnel_smoke.py
+++ b/cvms/dev/tests/tunnel_smoke.py
@@ -45,12 +45,12 @@ async def smoke():
     ssh = await asyncio.start_server(echo_server, "127.0.0.1", 0)
     ssh_port = ssh.sockets[0].getsockname()[1]
     config = tunnel_module.TunnelConfig(
-        "127.0.0.1", 0, "127.0.0.1", ssh_port, ("/umbra/tunnel", "/concrete/tunnel")
+        "127.0.0.1", 0, "127.0.0.1", ssh_port, ("/umbra/tunnel", "/legacy-cli/tunnel")
     )
     tunnel = await asyncio.start_server(lambda r, w: tunnel_module.handle_client(r, w, config), "127.0.0.1", 0)
     tunnel_port = tunnel.sockets[0].getsockname()[1]
-    # Both the canonical path and the concrete-CLI transition alias must relay.
-    for path in ("/umbra/tunnel", "/concrete/tunnel"):
+    # The canonical path and a configured alias must both relay.
+    for path in ("/umbra/tunnel", "/legacy-cli/tunnel"):
         reader, writer = await asyncio.open_connection("127.0.0.1", tunnel_port)
         key = base64.b64encode(os.urandom(16)).decode("ascii")
         writer.write(

--- a/cvms/dev/tests/user_sandbox_contract.py
+++ b/cvms/dev/tests/user_sandbox_contract.py
@@ -162,7 +162,7 @@ def main() -> None:
     )
     require("chown -R" not in entrypoint, "entrypoint must not recursively chown volumes")
     require(
-        re.search(r"dev-egress-forwarder:.*?healthcheck:\s+disable:\s+true", compose, re.DOTALL) is not None,
+        re.search(r'dev-egress-forwarder:.*?healthcheck:\s+test:\s+\["NONE"\]', compose, re.DOTALL) is not None,
         "forwarder must disable the inherited sshd image healthcheck",
     )
     user_sandbox = compose.split("  dev-egress-forwarder:", 1)[0]
@@ -171,7 +171,7 @@ def main() -> None:
         "sandbox CA bootstrap must receive the launch-bound Security CVM FQDN",
     )
     require(
-        re.search(r"dev-tunnel:.*?healthcheck:\s+disable:\s+true", compose, re.DOTALL) is not None,
+        re.search(r'dev-tunnel:.*?healthcheck:\s+test:\s+\["NONE"\]', compose, re.DOTALL) is not None,
         "tunnel must disable the inherited sshd image healthcheck",
     )
 

--- a/cvms/dev/user-sandbox/umbra-dev-tunnel.py
+++ b/cvms/dev/user-sandbox/umbra-dev-tunnel.py
@@ -27,8 +27,9 @@ class TunnelConfig:
 
 
 def load_config() -> TunnelConfig:
-    # /concrete/tunnel is a transition alias: concrete-branded CLIs (<= 0.4.x)
-    # dial it and must keep SSH access while users migrate to umbra-cli.
+    # DEV_TUNNEL_PATH is the comma-separated list of accepted upgrade paths.
+    # The Console injects the canonical path plus any operator-configured
+    # aliases kept for older clients (docs/specs/dev-cvm.md §7).
     return TunnelConfig(
         listen_host=os.environ.get("DEV_TUNNEL_HOST", "0.0.0.0"),
         listen_port=int(os.environ.get("DEV_TUNNEL_PORT", "8090")),
@@ -36,7 +37,7 @@ def load_config() -> TunnelConfig:
         ssh_port=int(os.environ.get("DEV_CVM_SSH_PORT", "22")),
         paths=tuple(
             part.strip()
-            for part in os.environ.get("DEV_TUNNEL_PATH", "/umbra/tunnel,/concrete/tunnel").split(",")
+            for part in os.environ.get("DEV_TUNNEL_PATH", "/umbra/tunnel").split(",")
             if part.strip()
         ),
     )

--- a/docs/specs/console.md
+++ b/docs/specs/console.md
@@ -2039,7 +2039,7 @@ Profile secret-injection values are write-only material encrypted outside `<Prof
 
 The Console strips `secret_injections[*].value` before writing `entity_profiles.policy`, upserts the corresponding encrypted rows here, and deletes rows for injections removed by policy replacement. A DB check constraint MUST reject `entity_profiles.policy` documents containing `secret_injections[*].value`, and active writes use `v2:` envelope format for `profile_secret_material.ciphertext`. User-facing profile reads MUST NOT return plaintext or ciphertext. Internal SC-control expands plaintext `value` only when rendering the Security CVM policy pull.
 
-Current writes use Umbra AAD `umbra.profile_secret_material.v2:{profile_id}:{injection_id}`; `v2:` is the active envelope version for all new rows. Reads remain compatibility-only for legacy `v1:` ciphertext bound to the historical AAD `concrete.profile_secret_material.v1:{profile_id}:{injection_id}` until an explicit decrypt-and-re-encrypt migration completes.
+Current writes use Umbra AAD `umbra.profile_secret_material.v2:{profile_id}:{injection_id}`; `v2:` is the active envelope version for all new rows. Reads remain compatibility-only for legacy `v1:` ciphertext bound to the historical AAD `{LEGACY_SECRET_AAD_NAMESPACE}.profile_secret_material.v1:{profile_id}:{injection_id}` until an explicit decrypt-and-re-encrypt migration completes. The namespace is operator configuration carried by migrated deployments; when unset (every fresh install), `v1:` reads MUST fail with a configuration error rather than fall back to any built-in value.
 
 `value_from` injections (§2.3) store nothing in this table — their material lives in `user_secret_material` (§7.6b) keyed by user, so policy replacement neither wipes nor rewrites it.
 
@@ -2051,7 +2051,7 @@ Per-user, host-bound secret values referenced by profile `secret_injections[*].v
 |---|---|---|
 | `user_id` | `UUID NOT NULL FK users.id CASCADE` | PK part 1. |
 | `name` | `VARCHAR(100) NOT NULL` | PK part 2. Matches `^[A-Za-z0-9._:-]{1,100}$`; referenced by `value_from.user_secret`. |
-| `ciphertext` | `TEXT NOT NULL` | AES-GCM envelope encrypted with `SECRET_INJECTION_KEK_B64` (same KEK as §7.6a), AAD `umbra.user_secret_material.v2:{user_id}:{name}` for active writes (`v2:` envelope). Legacy reads for historical `concrete.user_secret_material.v1:{user_id}:{name}` (`v1:` envelope) remain supported for migration only. |
+| `ciphertext` | `TEXT NOT NULL` | AES-GCM envelope encrypted with `SECRET_INJECTION_KEK_B64` (same KEK as §7.6a), AAD `umbra.user_secret_material.v2:{user_id}:{name}` for active writes (`v2:` envelope). Legacy reads for historical `{LEGACY_SECRET_AAD_NAMESPACE}.user_secret_material.v1:{user_id}:{name}` (`v1:` envelope) remain supported for migration only. |
 | `allowed_hosts` | `JSONB NOT NULL` | Non-empty array (≤ 16) of host-binding patterns in the `DestinationRule.host` grammar: exact host, `*.suffix`, or `*`. DB check: array type. |
 | `created_at` | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
 | `updated_at` | `TIMESTAMPTZ NOT NULL DEFAULT now()` | |
@@ -3227,7 +3227,7 @@ Cursor pagination uses a `(seq ASC)` keyset (the chain order, not the `timestamp
 `POST /audit/export` (§3.10) is gated by `AUDIT_EXPORT` (T-21) — distinct from `AUDIT_VIEW` because bulk export produces an artefact that survives outside the Console. The export Operation:
 
 1. Materialises the rows matching the supplied filters (paginating internally; row cap `1_000_000` per export).
-2. Streams them as `csv` or `ndjson` to the configured artifact store. v0 supports `file://` for local testing and an external Postgres store for production. The Postgres store MUST be separate from the Console runtime database and use credentials separate from `DATABASE_URL`; `AUDIT_EXPORT_BUCKET` is a `postgresql://`/`postgres://` DSN with optional `table=<identifier>` (active default `umbra_audit_export_artifacts`). Legacy deployments MAY set `table=concrete_audit_export_artifacts` only as an explicit migration window. The external table MUST be pre-created and grant the writer `INSERT, SELECT` only:
+2. Streams them as `csv` or `ndjson` to the configured artifact store. v0 supports `file://` for local testing and an external Postgres store for production. The Postgres store MUST be separate from the Console runtime database and use credentials separate from `DATABASE_URL`; `AUDIT_EXPORT_BUCKET` is a `postgresql://`/`postgres://` DSN with optional `table=<identifier>` (active default `umbra_audit_export_artifacts`). Legacy deployments MAY set `table=` to their pre-migration artifact table name only as an explicit migration window. The external table MUST be pre-created and grant the writer `INSERT, SELECT` only:
 
 ```
 CREATE TABLE umbra_audit_export_artifacts (
@@ -3269,7 +3269,7 @@ The replay processes every committed row in ascending `seq` order, from the firs
 The chain is anchored periodically to an external append-only store:
 
 - A scheduler-driven task (§9.2 step 5) takes the latest `(seq, row_hash)` and writes it to the configured external Postgres anchor store (`AUDIT_ANCHOR_TARGET`, §12). The bytes committed externally are `JCS({last_seq,last_row_hash,anchored_at,console_kid})`.
-- `AUDIT_ANCHOR_TARGET` MUST be a `postgresql://` or `postgres://` DSN for a database that is separate from the Console runtime database and uses credentials separate from `DATABASE_URL`. The optional query parameter `table=<identifier>` selects the external table name; the active default is `umbra_audit_anchors`. Legacy deployments MAY set `table=concrete_audit_anchors` only as an explicit migration window. Other query parameters are passed to the Postgres driver. The table MUST be pre-created by the operator:
+- `AUDIT_ANCHOR_TARGET` MUST be a `postgresql://` or `postgres://` DSN for a database that is separate from the Console runtime database and uses credentials separate from `DATABASE_URL`. The optional query parameter `table=<identifier>` selects the external table name; the active default is `umbra_audit_anchors`. Legacy deployments MAY set `table=` to their pre-migration anchor table name only as an explicit migration window. Other query parameters are passed to the Postgres driver. The table MUST be pre-created by the operator:
 
 ```
 CREATE TABLE umbra_audit_anchors (
@@ -3418,15 +3418,17 @@ The Console reads configuration from two sources: **plain values** (env vars or 
 | `RECONCILER_INTERVAL_SECONDS` | int ≥ 1 | `30` | Background loop interval. |
 | `OPERATION_RETENTION_DAYS` | int 1..365 | `30` | Per-operation TTL after `succeeded` / `failed` / `cancelled` (§7.17). |
 | `TRAFFIC_LOG_RETENTION_DAYS` | int 7..730 | `90` | Daily prune horizon for `traffic_logs` (§11.8). |
-| `AUDIT_ANCHOR_TARGET` | URI | (none, REQUIRED in production) | External Postgres anchor DSN (`postgresql://...` or `postgres://...`; optional `?table=<identifier>`, active default `umbra_audit_anchors`, with `concrete_audit_anchors` available only during explicit migration). §11.6. |
+| `AUDIT_ANCHOR_TARGET` | URI | (none, REQUIRED in production) | External Postgres anchor DSN (`postgresql://...` or `postgres://...`; optional `?table=<identifier>`, active default `umbra_audit_anchors`; a pre-migration table name is allowed only during explicit migration). §11.6. |
 | `AUDIT_ANCHOR_INTERVAL_SECONDS` | int 60..86400 | `3600` | Anchor cadence. |
-| `AUDIT_EXPORT_BUCKET` | URI | (none, REQUIRED for `POST /audit/export`) | Local `file://` bucket for development or external Postgres artifact-store DSN (`postgresql://...`; optional `?table=<identifier>`, active default `umbra_audit_export_artifacts`, with `concrete_audit_export_artifacts` available only during explicit migration). §11.5. |
+| `AUDIT_EXPORT_BUCKET` | URI | (none, REQUIRED for `POST /audit/export`) | Local `file://` bucket for development or external Postgres artifact-store DSN (`postgresql://...`; optional `?table=<identifier>`, active default `umbra_audit_export_artifacts`; a pre-migration table name is allowed only during explicit migration). §11.5. |
 | `METRICS_TOKEN` `secret` | string | `""` | Bearer token required by `GET /metrics` (§13.6). When empty, `/metrics` returns `503` so an unconfigured deployment does not accidentally expose metrics. |
 | `LOG_LEVEL` | enum `debug` / `info` / `warn` / `error` | `info` | Stdlib + structlog filter (§13.3). |
 | `TRUST_FORWARDED_HEADERS` | bool | `false` | When `true`, `X-Forwarded-For` is honored. MUST remain `false` unless fronted by a sanitising reverse proxy (§13.8). |
 | `AUTO_PROVISION_SECURITY_CVM_ON_PROFILE_CREATE` | bool | `false` | Logs an auto-provision marker on profile creation; the saga itself does not run inline. |
 | `UMBRA_ALLOW_BOOTSTRAP` | bool | `false` | Bootstrap (§12.3) refuses to run unless `true`. Not read elsewhere. |
 | `SANDBOX_ENV_VALUE_DENYLIST` | comma-list of regex | `^sk-ant-[A-Za-z0-9_-]+$,^sk-[A-Za-z0-9]{32,}$,^gh[pousr]_[A-Za-z0-9]{36,}$,^AKIA[0-9A-Z]{16}$,^ASIA[0-9A-Z]{16}$` | Patterns rejected by `policy.sandbox_env` validation (§2.3 `<Profile>`, §8.5). Defaults cover Anthropic, OpenAI, GitHub, and AWS access-key shapes; operators MAY extend with provider-specific patterns. |
+| `DEV_TUNNEL_EXTRA_PATHS` | comma-list of absolute URL paths | `""` | Alias tunnel paths for clients that predate `/umbra/tunnel`. Each entry is rendered as an additional Dev CVM route to `dev-tunnel:8090` and appended to the `DEV_TUNNEL_PATH` value injected at launch/update (dev-cvm spec §3.7, §4.3). |
+| `LEGACY_SECRET_AAD_NAMESPACE` | string | `""` | Historical AAD namespace for `v1:` secret envelopes written before the rename (§7.6a/§7.6b). Set only on migrated deployments; when unset, `v1:` reads fail with a configuration error. |
 
 ### 12.2 Secrets policy
 

--- a/docs/specs/dev-cvm.md
+++ b/docs/specs/dev-cvm.md
@@ -206,9 +206,11 @@ The image bakes Claude Code, Codex, and `gh` at known versions. The entrypoint M
 A small relay that:
 
 - Listens on TCP `:8090` (HTTP).
-- Accepts a WebSocket upgrade on `/umbra/tunnel`, and on `/concrete/tunnel`
-  as a transition alias for concrete-branded CLIs (<= 0.4.x); the alias is
-  removed once those CLIs are retired.
+- Accepts a WebSocket upgrade on every path listed in `DEV_TUNNEL_PATH`
+  (comma-separated; default `/umbra/tunnel`). The Console injects the
+  canonical path plus any aliases from its `DEV_TUNNEL_EXTRA_PATHS` setting;
+  aliases exist only so clients that predate the current path keep SSH access
+  and are removed once those clients are retired.
 - Bridges binary WebSocket frames to a TCP connection to `user-sandbox:22`.
 - Drops all capabilities (`cap_drop: [ALL]`), `read_only: true`, `security_opt: [no-new-privileges:true]`, `tmpfs: [/tmp]`.
 - Exposes no other endpoints.
@@ -266,7 +268,7 @@ The container's behavior is fully described by §3 (build) + §10 (boot sequence
 - Publishes ports `80:80` and `443:443` on the host.
 - Routes:
   - `POST /tdx_quote` → `attestation-service:8080` with `X-TLS-EKM-Channel-Binding: ${ekm_hex}:${hmac_hex}` (RFC 5705 EKM exporter `EXPORTER-Channel-Binding`, 32 bytes; `hmac_hex` = HMAC-SHA256(`ekm_raw`, in-TEE HMAC key)).
-  - `GET /umbra/tunnel` (WebSocket upgrade) → `dev-tunnel:8090`. `proxy_read_timeout` and `proxy_send_timeout` MUST be ≥ 3600s. `GET /concrete/tunnel` routes identically as the concrete-CLI transition alias.
+  - `GET /umbra/tunnel` (WebSocket upgrade) → `dev-tunnel:8090`. `proxy_read_timeout` and `proxy_send_timeout` MUST be ≥ 3600s. Every operator-configured alias path (Console `DEV_TUNNEL_EXTRA_PATHS`) routes identically.
 - All other paths MUST return 404.
 
 ### 4.4 `attestation-service` runtime (shade)

--- a/ops/reverse-proxy/Dockerfile
+++ b/ops/reverse-proxy/Dockerfile
@@ -57,10 +57,10 @@ RUN apk add --no-cache \
       py3-tz-pyc=2026.2-r0 \
       py3-urllib3=2.7.0-r0 \
       py3-urllib3-pyc=2.7.0-r0 \
-      pyc=3.14.7-r0 \
-      python3=3.14.7-r0 \
-      python3-pyc=3.14.7-r0 \
-      python3-pycache-pyc0=3.14.7-r0 \
+      pyc=3.14.7-r1 \
+      python3=3.14.7-r1 \
+      python3-pyc=3.14.7-r1 \
+      python3-pycache-pyc0=3.14.7-r1 \
       readline=8.3.3-r1 \
       sqlite-libs=3.53.2-r0
 


### PR DESCRIPTION
Promotes the staging-verified lineage to main for the first public CLI release (0.1.0).

- fix(tests): match the sandbox contract to the test NONE healthcheck spelling
- feat(console,cvm): move legacy client aliases and the v1 AAD namespace into operator configuration
- chore: finish the product rename in residual literals
- chore(release): set the first public CLI version to 0.1.0
- fix(ops): refresh the reverse-proxy python3 package pins

Head commit 5545a599 is the candidate verified by the staging deploy-verify gate and running in production.