### PR TITLE
fix(release): recover the unpublished 0.1.0 distribution

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -224,10 +224,35 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: umbra-cli-${{ matrix.target }}
-          path: dist/
+          path: |
+            dist/${{ needs.metadata.outputs.version }}/
+            dist/latest/
+
+  validate-binary-artifacts:
+    needs: [metadata, binary-artifacts]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
+      - name: Download target artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: umbra-cli-*-*-*
+          path: artifacts
+          merge-multiple: true
+      - name: Validate distribution before immutable publication
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          tar -C artifacts -czf release-tree.tar.gz .
+          python3 ops/cli-release/extract-cli-release-tree.py \
+            release-tree.tar.gz verified-tree "${VERSION}"
 
   publish:
-    needs: [metadata, package, binary-artifacts]
+    needs: [metadata, package, binary-artifacts, validate-binary-artifacts]
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/recover-cli-0.1.0.yml
+++ b/.github/workflows/recover-cli-0.1.0.yml
@@ -1,0 +1,78 @@
+name: Recover Umbra CLI 0.1.0 draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Must be false to generate signed recovery artifacts; does not publish them'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: recover-cli-0.1.0
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      subjects: ${{ steps.subjects.outputs.base64 }}
+    steps:
+      - name: Require protected source
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REPOSITORY" == concrete-security/umbra ]]
+          [[ "$GITHUB_REF" == refs/heads/main ]]
+      - name: Checkout packaging source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
+      - name: Validate original run and unchanged tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api repos/concrete-security/umbra/actions/runs/34103392444 > original-run.json
+          jq -e '.head_sha == "0bd721e93585a65353bd52935235affb9b5d3746" and .head_branch == "main" and .conclusion == "success" and .path == ".github/workflows/publish-cli.yml"' original-run.json
+          tag_sha="$(gh api repos/concrete-security/umbra/git/ref/tags/umbra-cli/0.1.0 --jq .object.sha)"
+          [[ "$tag_sha" == 0bd721e93585a65353bd52935235affb9b5d3746 ]]
+          gh run download 34103392444 -R concrete-security/umbra -n umbra-cli-release-tree -D original
+          gh run download 34103392444 -R concrete-security/umbra -n umbra-cli.intoto.jsonl -D original
+      - name: Build pinned provenance verifier
+        env:
+          GOBIN: ${{ runner.temp }}/verifier
+          GOPROXY: https://proxy.golang.org
+          GOSUMDB: sum.golang.org
+        run: go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
+      - name: Repackage verified original binaries
+        run: |
+          python3 ops/cli-release/recover-0.1.0.py original recovered \
+            --verifier "$RUNNER_TEMP/verifier/slsa-verifier" --packaging-commit "$GITHUB_SHA"
+      - name: Encode independently checked subjects
+        id: subjects
+        run: echo "base64=$(base64 -w0 recovered/provenance-subjects.sha256)" >> "$GITHUB_OUTPUT"
+      - name: Upload recovery artifacts for independent verification
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: umbra-cli-recovered-0.1.0
+          path: recovered/
+          if-no-files-found: error
+  provenance:
+    needs: recover
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    with:
+      base64-subjects: ${{ needs.recover.outputs.subjects }}
+      provenance-name: umbra-cli.intoto.jsonl
+      upload-assets: false

--- a/.github/workflows/recover-cli-0.1.0.yml
+++ b/.github/workflows/recover-cli-0.1.0.yml
@@ -52,9 +52,14 @@ jobs:
           GOPROXY: https://proxy.golang.org
           GOSUMDB: sum.golang.org
         run: go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
+      - name: Install pinned Python runner
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: 0.12.1
+          enable-cache: 'false'
       - name: Repackage verified original binaries
         run: |
-          python3 ops/cli-release/recover-0.1.0.py original recovered \
+          uv run --python "$(cat .python-version)" --no-project python ops/cli-release/recover-0.1.0.py original recovered \
             --verifier "$RUNNER_TEMP/verifier/slsa-verifier" --packaging-commit "$GITHUB_SHA"
       - name: Encode independently checked subjects
         id: subjects

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -125,3 +125,21 @@ No external issue-tracker integration is required by this repository.
 4. Update the private deployment repository to pin those exact public identifiers, verify them in staging, then promote the same digests to production under the private deployment gates.
 
 No public-repository workflow deploys a maintainer-operated environment.
+
+## One-time CLI 0.1.0 draft recovery
+
+`recover-cli-0.1.0.yml` is the explicitly approved packaging recovery for the
+unpublished GitHub 0.1.0 draft. It does not publish crates, move tags, or replace
+release assets. It verifies the pinned original successful run and SLSA evidence,
+removes only the accidentally included skill, and retains the original binary
+bytes. The strict distribution extractor remains unchanged. A signed repair
+receipt links the original binary source to the new packaging commit; original
+archive, checksums and provenance are retained as separate evidence.
+
+After independent verification of the new SLSA evidence, an authorized operator
+may replace only the archive, checksum manifest and provenance while the release
+remains a draft and its tag and original asset IDs/digests remain unchanged.
+Preserve the original evidence and signed receipt alongside the release. Verify
+the re-downloaded canonical assets and isolated installation before publishing.
+This exception does not apply to public releases or change normal publication's
+byte-identity checks. Production installer-mirror deployment is separate.

--- a/ops/cli-release/recover-0.1.0-inputs.json
+++ b/ops/cli-release/recover-0.1.0-inputs.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.1.0",
+  "source_commit": "0bd721e93585a65353bd52935235affb9b5d3746",
+  "source_run": 34103392444,
+  "source_epoch": 1788771463,
+  "crate_checksum": "0018d876dae6c8837e424fca8edef7ce80e95156edd88474ff4945e5451a3e14",
+  "assets": {
+    "SHA256SUMS": "4e1883252023f9b50862b03299a478df8ddab55d7f00103f7d7ee6ca92869c36",
+    "umbra-cli-aarch64-apple-darwin.cdx.json": "db28076e595f9c964f981032be600d214a906c86a73448659647ad3815d4a3dc",
+    "umbra-cli-aarch64-unknown-linux-gnu.cdx.json": "622d20f2ab324c64fffdb5641a414d5de87e0262dfd2676b22950ca875e4429d",
+    "umbra-cli-release-tree.tar.gz": "a324cbfb4a1a85fa1cdb16656ca22118abe6c0c20c55c33b98b202bcf20b6571",
+    "umbra-cli-x86_64-unknown-linux-gnu.cdx.json": "dfbe389aad57b62c9bb743bcc32e30267f54b3ae3533697a78eba96344576f66",
+    "umbra-cli.intoto.jsonl": "0b8832ebf5e29a9eace1171641a8eb76ef81a27d099ec347b74c1a936479bfd2",
+    "umbra-install.sh": "7cf045ae214a0f19ac6b571fe6397cea19ab83f61267f536a72659fc201d047a"
+  }
+}

--- a/ops/cli-release/recover-0.1.0.py
+++ b/ops/cli-release/recover-0.1.0.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Repackage only the pinned, unpublished 0.1.0 distribution; never rebuild binaries."""
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import hashlib
+import io
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tarfile
+
+HERE = Path(__file__).resolve().parent
+BUILDER = 'https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.1.0'
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('inputs', type=Path)
+    parser.add_argument('output', type=Path)
+    parser.add_argument('--verifier', required=True)
+    parser.add_argument('--packaging-commit', required=True)
+    args = parser.parse_args()
+    require(bool(re.fullmatch('[0-9a-f]{40}', args.packaging_commit)), 'invalid packaging commit')
+    pins = json.loads((HERE / 'recover-0.1.0-inputs.json').read_text())
+    original = {}
+    paths = {}
+    for name, checksum in pins['assets'].items():
+        matches = list(args.inputs.rglob(name))
+        require(len(matches) == 1, f'expected exactly one input: {name}')
+        paths[name] = matches[0]
+        original[name] = matches[0].read_bytes()
+        require(digest(original[name]) == checksum, f'original digest mismatch: {name}')
+    provenance_name = 'umbra-cli.intoto.jsonl'
+    subprocess.run([
+        args.verifier, 'verify-artifact',
+        *[str(paths[name]) for name in original if name != provenance_name],
+        '--provenance-path', str(paths[provenance_name]),
+        '--source-uri', 'github.com/concrete-security/umbra',
+        '--source-branch', 'main', '--build-workflow-input', 'dry_run=false',
+        '--builder-id', BUILDER,
+    ], check=True)
+    envelope = json.loads(original[provenance_name])['dsseEnvelope']
+    statement = json.loads(base64.b64decode(envelope['payload']))
+    invocation = statement['predicate']['invocation']
+    require(invocation['configSource']['digest']['sha1'] == pins['source_commit'], 'wrong binary source commit')
+    require(invocation['environment']['github_run_id'] == str(pins['source_run']), 'wrong original run')
+    require(invocation['configSource']['entryPoint'] == '.github/workflows/publish-cli.yml', 'wrong original workflow')
+    subjects = {item['name']: item['digest']['sha256'] for item in statement['subject']}
+    manifest = dict((line.split('  ', 1)[1], line.split('  ', 1)[0])
+                    for line in original['SHA256SUMS'].decode().splitlines())
+    require(manifest['umbra-cli-0.1.0.crate'] == pins['crate_checksum'], 'wrong crate checksum')
+    require(subjects['umbra-cli-0.1.0.crate'] == pins['crate_checksum'], 'wrong signed crate checksum')
+    archive_name = 'umbra-cli-release-tree.tar.gz'
+    kept = []
+    removed = set()
+    binary_hashes = {}
+    with tarfile.open(fileobj=io.BytesIO(original[archive_name]), mode='r:gz') as archive:
+        for member in archive:
+            name = member.name.removeprefix('./')
+            if name in {'skills', 'skills/umbra-cli', 'skills/umbra-cli/SKILL.md'}:
+                removed.add(name)
+                continue
+            require(member.isdir() or member.isfile(), 'link or special entry in original archive')
+            data = archive.extractfile(member).read() if member.isfile() else None
+            kept.append((member, data))
+            if name.startswith('0.1.0/') and name.endswith('/umbra'):
+                checksum = digest(data)
+                require(subjects.get(name) == checksum == manifest.get(name), f'unsigned binary: {name}')
+                binary_hashes[name] = checksum
+    require(removed == {'skills', 'skills/umbra-cli', 'skills/umbra-cli/SKILL.md'}, 'unexpected discarded layout')
+    require(len(binary_hashes) == 3, 'expected three original binaries')
+    args.output.mkdir(parents=True, exist_ok=False)
+    with (args.output / archive_name).open('wb') as raw:
+        with gzip.GzipFile(fileobj=raw, mode='wb', filename='', mtime=0) as compressed:
+            with tarfile.open(fileobj=compressed, mode='w', format=tarfile.GNU_FORMAT) as repaired:
+                for member, data in sorted(kept, key=lambda item: item[0].name):
+                    member.uid = member.gid = 0
+                    member.uname = member.gname = ''
+                    member.mtime = pins['source_epoch']
+                    repaired.addfile(member, io.BytesIO(data) if data is not None else None)
+    extracted = args.output / 'verified-tree'
+    subprocess.run(['python3', str(HERE / 'extract-cli-release-tree.py'),
+                    str(args.output / archive_name), str(extracted), '0.1.0'], check=True)
+    for name, checksum in binary_hashes.items():
+        require(digest(extracted.joinpath(name).read_bytes()) == checksum, 'binary changed during recovery')
+    shutil.rmtree(extracted)
+    for name, data in original.items():
+        if name not in {archive_name, 'SHA256SUMS', provenance_name}:
+            (args.output / name).write_bytes(data)
+    evidence_names = {
+        archive_name: 'umbra-cli-original-release-tree.tar.gz',
+        'SHA256SUMS': 'umbra-cli-original-SHA256SUMS',
+        provenance_name: 'umbra-cli-original.intoto.jsonl',
+    }
+    for source, target in evidence_names.items():
+        (args.output / target).write_bytes(original[source])
+    receipt = {
+        'operation': 'remove tracked skill from unpublished 0.1.0 distribution',
+        'binary_source_commit': pins['source_commit'],
+        'binary_source_run': pins['source_run'],
+        'packaging_commit': args.packaging_commit,
+        'original_assets': pins['assets'],
+        'repaired_archive_sha256': digest((args.output / archive_name).read_bytes()),
+        'unchanged_binary_sha256': binary_hashes,
+        'unchanged_crate_sha256': pins['crate_checksum'],
+        'removed_entries': sorted(removed),
+    }
+    (args.output / 'umbra-cli-repair-receipt.json').write_text(json.dumps(receipt, indent=2, sort_keys=True) + '\n')
+    for path in args.output.iterdir():
+        manifest[path.name] = digest(path.read_bytes())
+    (args.output / 'SHA256SUMS').write_text(''.join(f'{checksum}  {name}\n' for name, checksum in sorted(manifest.items())))
+    subprocess.run(['python3', str(HERE / 'verify-cli-release-manifest.py'),
+                    str(args.output / 'SHA256SUMS'), '0.1.0',
+                    *[str(path) for path in args.output.iterdir() if path.name != 'SHA256SUMS']], check=True)
+    manifest['SHA256SUMS'] = digest((args.output / 'SHA256SUMS').read_bytes())
+    subjects_text = ''.join(f'{checksum}  {name}\n' for name, checksum in sorted(manifest.items()))
+    (args.output / 'provenance-subjects.sha256').write_text(subjects_text)
+    print('Verified recovery: all three original signed binaries are unchanged.')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/check-github-actions.py
+++ b/tools/check-github-actions.py
@@ -250,6 +250,8 @@ def action_reference_failures(root: Path = REPO_ROOT) -> list[str]:
     """Return mutable, malformed, or missing SLSA workflow reference findings."""
     failures: list[str] = []
     slsa_references: list[str] = []
+    recovery_references: list[str] = []
+    recovery_path = Path(".github/workflows/recover-cli-0.1.0.yml")
     files = action_files(root)
     if not files:
         return ["no GitHub Actions workflow or composite-action manifests found"]
@@ -288,12 +290,18 @@ def action_reference_failures(root: Path = REPO_ROOT) -> list[str]:
                 elif local_manifest is not None:
                     files.append(local_manifest)
             if reference.partition("@")[0] == SLSA_REUSABLE_PATH:
-                slsa_references.append(reference)
+                if display_path == recovery_path:
+                    recovery_references.append(reference)
+                else:
+                    slsa_references.append(reference)
             if reference_allowed(reference):
                 continue
             failures.append(
                 f"{display_path}:{line_number}: mutable Actions reference {reference}"
             )
+
+    if (root / recovery_path).exists() and recovery_references != [SLSA_REUSABLE_REF]:
+        failures.append("0.1.0 recovery must have exactly one reference to " + SLSA_REUSABLE_REF)
 
     if slsa_references != [SLSA_REUSABLE_REF]:
         rendered = ", ".join(slsa_references) if slsa_references else "none"

--- a/tools/test_check_github_actions.py
+++ b/tools/test_check_github_actions.py
@@ -532,3 +532,31 @@ def test_repository_workflow_cache_policy_success() -> None:
     """Checked-in workflows keep the cache trust boundary mechanically pinned."""
 
     assert checker.workflow_cache_policy_failures(checker.REPO_ROOT) == []
+
+
+@pytest.mark.parametrize("count", [0, 2])
+def test_recovery_slsa_reference_count_failure(tmp_path: Path, count: int) -> None:
+    """Recovery cannot omit its signer or add multiple signing references."""
+    workflows = tmp_path / ".github/workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "publish-cli.yml").write_text(
+        f"jobs: {{sign: {{uses: {checker.SLSA_REUSABLE_REF}}}}}\n"
+    )
+    (workflows / "recover-cli-0.1.0.yml").write_text(
+        "jobs:\n" + "".join(
+            f"  sign{i}: {{uses: {checker.SLSA_REUSABLE_REF}}}\n" for i in range(count)
+        )
+    )
+    assert any("recovery must have exactly one" in failure
+               for failure in checker.action_reference_failures(tmp_path))
+
+
+def test_recovery_slsa_reference_success(tmp_path: Path) -> None:
+    """Only the named recovery workflow receives the additional exact signer."""
+    workflows = tmp_path / ".github/workflows"
+    workflows.mkdir(parents=True)
+    for name in ("publish-cli.yml", "recover-cli-0.1.0.yml"):
+        (workflows / name).write_text(
+            f"jobs: {{sign: {{uses: {checker.SLSA_REUSABLE_REF}}}}}\n"
+        )
+    assert checker.action_reference_failures(tmp_path) == []


### PR DESCRIPTION
The 0.1.0 workflow uploaded tracked `dist/skills/umbra-cli/SKILL.md` with the binary tree, causing the strict extractor to reject the signed archive. Limit future uploads to version/latest and validate the assembled tree before crates.io publication.

Add the explicitly approved, one-time recovery workflow for the unpublished 0.1.0 GitHub draft. It verifies pinned original assets and SLSA source identity, retains binary bytes and original evidence, and produces a corrected tree and signed repair receipt. It does not publish crates, move tags, or replace release assets. A separately authorized operator must verify the fresh provenance and unchanged draft before replacing only the archive, manifest and provenance. Published-release immutability and the extractor are unchanged.

Validation: recovery from the actual signed release assets succeeds with all three binary digests unchanged; altered original manifest is rejected before output creation; 53 Actions checker tests pass; exact signer pins and diff whitespace checks pass. End-to-end signed installation follows CI signing.
